### PR TITLE
Replace float values for decimal

### DIFF
--- a/feeds_flatstore_processor.module
+++ b/feeds_flatstore_processor.module
@@ -295,7 +295,7 @@ function feeds_flatstore_processor_find_columns($parsed_result, $limit, $headers
   $colcount = count($headers);
 
   // List of possible types, from least to most specific.
-  $types = array('bigtext' => 0, 'datetime' => 0, 'float' => 0, 'int' => 0, 'bigint' => 0);
+  $types = array('bigtext' => 0, 'datetime' => 0, 'decimal' => 0, 'int' => 0, 'bigint' => 0);
   $type_counter = array();
   foreach ($headers as $key => $value) {
     $type_counter[$key]  = $types;
@@ -315,9 +315,9 @@ function feeds_flatstore_processor_find_columns($parsed_result, $limit, $headers
         $type_counter[$key]['int']++;
       }
 
-      // Float.
+      // Decimal.
       elseif (preg_match('/^-?(?:\d+|\d*\.\d+)$/', trim($value))) {
-        $type_counter[$key]['float']++;
+        $type_counter[$key]['decimal']++;
       }
 
       // Datetime.


### PR DESCRIPTION
Filters don't work with float numbers. If you try to use a filter in a float column it won't work because internally float numbers may not be stored in the same way we insert them. For example: 43.23 can be stored as 43.229999999999999. This replace the float type by the decimal type that works as we expect.