### PR TITLE
Fix datastore replaces NA values as zeros.

### DIFF
--- a/FeedsFlatstoreProcessor.inc
+++ b/FeedsFlatstoreProcessor.inc
@@ -57,6 +57,13 @@ class FeedsFlatstoreProcessor extends FeedsProcessor {
         $cleaned_data = $this->geocode($cleaned_data, $source_config['geolocate_addresses'], $source_config['geolocater']);
       }
 
+      // Empty values should be nullified CIVIC-5364
+      foreach ($cleaned_data as $key => $value) {
+        if (empty($value) && !is_numeric($value)) {
+          $cleaned_data[$key] = NULL;
+        }
+      }
+
       // We only save, never update, since there is only a flat table.
       $this->handler($source)->save($cleaned_data);
     }


### PR DESCRIPTION
REF CIVIC-5354

When loading properly delimited data files into the datastore, columns with no
values (literally "NULL" or "NA" in programs like R or Python) displayed in the
raw data as two pipes next to each other with nothing in between them, is being
brought into the datastore with a value of zero. This may be critically
misleading for almost every dataset that it occurs in. It seems to affect only
columns that DKAN thinks are numeric.One silver lining, if a user downloads the
raw file this should be not affect them as they will be receiving a straight
copy of what we uploaded. Please see screenshots below.

QA Steps
==
- [x] Empty data in CSVs is not replaced by zeros when imported into the datastore
- [x] Behavior is consistent for all supported file delimiters (, ; + | TAB)
- [x] Datastore API returns a NULL value if a CSV with empty data is imported