### PR TITLE
Change from 'TAB' to the tab delimiter character.

### DIFF
--- a/feeds_flatstore_processor.module
+++ b/feeds_flatstore_processor.module
@@ -265,6 +265,10 @@ function feeds_flatstore_processor_get_csv_results($filepath, $separator = ",", 
     drupal_set_message(t('Could not open !filename', array('!filename' => $filepath)));
     return FALSE;
   }
+  // If the field delimiter is a TAB, then use the tab character.
+  if ($separator == 'TAB') {
+    $separator = "\t";
+  }
 
   $parsed_results = array();
   $rowcount = 0;


### PR DESCRIPTION
Issue:  CIVIC-6058.

## Description 

Tab delimited csv files are not being imported correctly in the datastore: the resulting data is not separated as expected.
When you try to do the import in the watchdog logs we get the following notice:

`Notice: fgetcsv(): delimiter must be a single character in feeds_flatstore_processor_get_csv_results() (line 278 of /var/www/dkan/modules/contrib/feeds_flatstore_processor/feeds_flatstore_processor.module).`

So, here we are checking if the delimiter used is 'TAB' and if that's the case, we use the tab delimiter character "\t".